### PR TITLE
[add] 指定した日の日記のみの取得&指定した月の日記を書いた日付を返すAPIを追加

### DIFF
--- a/public/sqltest.html
+++ b/public/sqltest.html
@@ -16,16 +16,14 @@
 
   <script type="module">
     // greetingを叩くためのjavascriptの実装
-    const today = '2023/03/31';
+    const today = '2023/08/31';
     document.getElementById("auth").onclick = async () => {
       const pass = document.getElementById("password").value;
-      const response = await fetch("/insert-diary",{
+      const response = await fetch("/diary-date",{
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
         body: JSON.stringify({
           date: today,
-          weather: 2,
-          text: pass,
         })
       });
       document.getElementById("server_response").innerText = await response.text();


### PR DESCRIPTION
- 指定した日の日記のみを取得する機能を追加しました。 - /get-daydiaryにGETでアクセスすると、引数dateで指定された日の日記の身を返します。
- 指定した月の日記を書いた日を返す機能を追加しました。 - /diary-dateにPOSTでアクセスすると引数dateの月(8/7なら8月)の日記を書いた日をYYYY-MM-DDで配列で返します。
- 必要のない出力を削除しました。